### PR TITLE
Resolve Missing Export in Bluetooth Service

### DIFF
--- a/web/src/services/bluetoothService.ts
+++ b/web/src/services/bluetoothService.ts
@@ -3,6 +3,8 @@
  * Supports standard Bluetooth GATT services for health monitoring devices
  */
 
+import type { BluetoothDeviceInfo, VitalsReading } from './types';
+
 // Standard Bluetooth GATT Service UUIDs
 const SERVICES = {
   HEART_RATE: 0x180d,
@@ -23,25 +25,6 @@ const CHARACTERISTICS = {
   PLX_SPOT_CHECK: 0x2a5e,
   BATTERY_LEVEL: 0x2a19,
 } as const;
-
-export interface BluetoothDeviceInfo {
-  id: string;
-  name: string;
-  type: string;
-  manufacturer?: string;
-  batteryLevel?: number;
-}
-
-export interface VitalsReading {
-  heartRate?: number;
-  bloodPressureSystolic?: number;
-  bloodPressureDiastolic?: number;
-  oxygenLevel?: number;
-  temperature?: number;
-  glucose?: number;
-  timestamp: Date;
-  deviceId: string;
-}
 
 class BluetoothService {
   private connectedDevices: Map<string, BluetoothDevice> = new Map();

--- a/web/src/services/healthPlatformService.ts
+++ b/web/src/services/healthPlatformService.ts
@@ -3,7 +3,7 @@
  * This service provides a unified interface for accessing health data from various platforms
  */
 
-import { VitalsReading } from './bluetoothService';
+import type { VitalsReading, HealthPlatformConfig, DataPoint } from './types';
 
 // Google Fit API configuration
 const GOOGLE_FIT_SCOPES = [
@@ -23,17 +23,6 @@ const DATA_TYPES = {
   OXYGEN_SATURATION: 'com.google.oxygen_saturation',
   HEART_RATE_VARIABILITY: 'com.google.heart_rate.variability',
 };
-
-export interface HealthPlatformConfig {
-  googleFitClientId?: string;
-  appleHealthEnabled?: boolean;
-}
-
-export interface DataPoint {
-  value: number;
-  timestamp: Date;
-  dataType: string;
-}
 
 class HealthPlatformService {
   private googleAuth: any = null;

--- a/web/src/services/types.ts
+++ b/web/src/services/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared type definitions for health monitoring services
+ */
+
+export interface VitalsReading {
+  heartRate?: number;
+  bloodPressureSystolic?: number;
+  bloodPressureDiastolic?: number;
+  oxygenLevel?: number;
+  temperature?: number;
+  glucose?: number;
+  timestamp: Date;
+  deviceId: string;
+}
+
+export interface BluetoothDeviceInfo {
+  id: string;
+  name: string;
+  type: string;
+  manufacturer?: string;
+  batteryLevel?: number;
+}
+
+export interface DataPoint {
+  value: number;
+  timestamp: Date;
+  dataType: string;
+}
+
+export interface HealthPlatformConfig {
+  googleFitClientId?: string;
+  appleHealthEnabled?: boolean;
+}
+
+export interface SyncConfig {
+  userId: string;
+  autoSyncInterval?: number; // minutes
+  googleFitClientId?: string;
+}
+
+export interface SyncStatus {
+  isBluetoothConnected: boolean;
+  isGoogleFitConnected: boolean;
+  lastSyncTime?: Date;
+  syncedDevices: string[];
+}

--- a/web/src/services/vitalsSyncService.ts
+++ b/web/src/services/vitalsSyncService.ts
@@ -6,21 +6,9 @@
 
 import { collection, addDoc, Timestamp, doc, updateDoc } from 'firebase/firestore';
 import { db } from './firebase';
-import { bluetoothService, VitalsReading } from './bluetoothService';
+import { bluetoothService } from './bluetoothService';
 import { healthPlatformService } from './healthPlatformService';
-
-export interface SyncConfig {
-  userId: string;
-  autoSyncInterval?: number; // minutes
-  googleFitClientId?: string;
-}
-
-export interface SyncStatus {
-  isBluetoothConnected: boolean;
-  isGoogleFitConnected: boolean;
-  lastSyncTime?: Date;
-  syncedDevices: string[];
-}
+import type { VitalsReading, SyncConfig, SyncStatus } from './types';
 
 class VitalsSyncService {
   private config?: SyncConfig;


### PR DESCRIPTION
Create a centralized types.ts file for shared interfaces used across multiple services (bluetoothService, healthPlatformService, vitalsSyncService).

This fixes the SyntaxError where healthPlatformService was unable to import VitalsReading from bluetoothService. TypeScript interfaces are type-only exports that get erased during compilation, causing runtime module resolution errors.

Changes:
- Created web/src/services/types.ts with shared type definitions
- Updated bluetoothService.ts to import types from types.ts
- Updated healthPlatformService.ts to import types from types.ts
- Updated vitalsSyncService.ts to import types from types.ts
